### PR TITLE
Fix matroid intersection

### DIFF
--- a/combinatorial_opt/matroid_intersection.hpp
+++ b/combinatorial_opt/matroid_intersection.hpp
@@ -3,44 +3,73 @@
 #include <cassert>
 #include <vector>
 
-// (Min weight) matroid intersection solver
-// Algorithm based on http://dopal.cs.uec.ac.jp/okamotoy/lect/2015/matroid/
-// Complexity: O(CE^2 + E^3) (C : circuit query, non-weighted)
-template <class M1, class M2, class T = int>
-std::vector<bool> MatroidIntersection(M1 matroid1, M2 matroid2, std::vector<T> weights = {}) {
-    using State = std::vector<bool>;
-    using Element = int;
-    assert(matroid1.size() == matroid2.size());
-    const int M = matroid1.size();
+// Find augmenting path of matroid intersection.
+// m1, m2: matroids
+// I: independent set (will be updated if augmenting path is found)
+//
+// Return `true` iff augmenting path is found.
+// Complexity: O(Cn + n^2) (C: circuit query)
+template <class Matroid1, class Matroid2, class T = int>
+bool matroid_intersection_augment(Matroid1 &m1, Matroid2 &m2, std::vector<bool> &I,
+                                  const std::vector<T> &weights = {}) {
+    const int n = m1.size();
+    assert(m2.size() == n);
+    assert((int)I.size() == n);
 
-    for (auto &x : weights) x *= M + 1;
-    if (weights.empty()) weights.assign(M, 0);
+    auto weight = [&](int e) { return weights.empty() ? T() : weights.at(e) * (n + 1); };
 
-    const Element gs = M, gt = M + 1;
-    State I(M);
-
-    while (true) {
-        shortest_path<T> sssp(M + 2);
-        matroid1.set(I);
-        matroid2.set(I);
-        for (int e = 0; e < M; e++) {
-            if (I[e]) continue;
-            auto c1 = matroid1.circuit(e), c2 = matroid2.circuit(e);
-            if (c1.empty()) sssp.add_edge(e, gt, 0);
-            for (Element f : c1) {
-                if (f != e) sssp.add_edge(e, f, -weights[f] + 1);
-            }
-            if (c2.empty()) sssp.add_edge(gs, e, weights[e] + 1);
-            for (Element f : c2) {
-                if (f != e) sssp.add_edge(f, e, weights[e] + 1);
-            }
+    const int gs = n, gt = n + 1;
+    shortest_path<T> sssp(n + 2);
+    m1.set(I);
+    m2.set(I);
+    for (int e = 0; e < n; ++e) {
+        if (I.at(e)) continue;
+        auto c1 = m1.circuit(e), c2 = m2.circuit(e);
+        if (c1.empty()) sssp.add_edge(e, gt, T());
+        for (int f : c1) {
+            if (f != e) sssp.add_edge(e, f, -weight(f) + T(1));
         }
-        sssp.solve(gs, gt);
-        auto aug_path = sssp.retrieve_path(gt);
-        if (aug_path.empty()) break;
-        for (auto e : aug_path) {
-            if (e != gs and e != gt) I[e] = !I[e];
+        if (c2.empty()) sssp.add_edge(gs, e, weight(e) + T(1));
+        for (int f : c2) {
+            if (f != e) sssp.add_edge(f, e, weight(e) + T(1));
         }
     }
+    sssp.solve(gs, gt);
+
+    if (auto aug_path = sssp.retrieve_path(gt); aug_path.empty()) {
+        return false;
+    } else {
+        for (auto e : aug_path) {
+            if (e != gs and e != gt) I.at(e) = !I.at(e);
+        }
+        return true;
+    }
+}
+
+// (Min weight) matroid intersection solver
+// Algorithm based on http://dopal.cs.uec.ac.jp/okamotoy/lect/2015/matroid/
+// Complexity: O(Cn^2 + n^3) (C : circuit query, non-weighted)
+template <class Matroid1, class Matroid2, class T = int>
+std::vector<bool>
+MatroidIntersection(Matroid1 matroid1, Matroid2 matroid2, std::vector<T> weights = {}) {
+    const int n = matroid1.size();
+    assert(matroid2.size() == n);
+    assert(weights.empty() or (int) weights.size() == n);
+
+    std::vector<bool> I(n);
+
+    if (weights.empty()) {
+        matroid1.set(I);
+        matroid2.set(I);
+        for (int e = 0; e < n; ++e) {
+            if (matroid1.circuit(e).empty() and matroid2.circuit(e).empty()) {
+                I.at(e) = true;
+                matroid1.set(I);
+                matroid2.set(I);
+            }
+        }
+    }
+
+    while (matroid_intersection_augment(matroid1, matroid2, I, weights)) {}
     return I;
 }

--- a/combinatorial_opt/matroid_intersection.md
+++ b/combinatorial_opt/matroid_intersection.md
@@ -14,10 +14,10 @@ $M\_{1} = (E, \mathcal{I}\_{1}), M_{2} = (E, \mathcal{I}\_{2})$ が与えられ�
 
 ```cpp
 UserDefinedMatroid m1, m2;
-vector<int> weights(M);
+vector<int> weights(n);
 
-assert(m1.size() == M);
-assert(m2.size() == M);
+assert(m1.size() == n);
+assert(m2.size() == n);
 
 std::vector<bool> maxindepset = MatroidIntersection(m1, m2, weights);
 ```
@@ -27,7 +27,7 @@ std::vector<bool> maxindepset = MatroidIntersection(m1, m2, weights);
 - [Hello 2020 G. Seollal - Codeforces](https://codeforces.com/contest/1284/problem/G) グラフマトロイドと分割マトロイドの交差に帰着される．
 - [Deltix Round, Summer 2021 H. DIY Tree - Codeforces](https://codeforces.com/contest/1556/problem/H) 少数の頂点に次数制約がついた最小全域木問題．グラフマトロイドと分割マトロイドの最小重み共通独立集合問題に帰着される．
 - [2019 Petrozavodsk Winter Camp, Yandex Cup D. Pick Your Own Nim - Codeforces](https://codeforces.com/gym/102156/problem/D) 二値マトロイドと分割マトロイドの交差．
-- [2128 - Demonstration of Honesty! - URI Online Judge](https://www.urionlinejudge.com.br/judge/en/problems/view/2128) 各辺に色がついている無向グラフで，同色の辺は一度しか使えない全域木構築判定問題．グラフマトロイドと分割マトロイドの交差．このライブラリでは TL が厳しいが，独立性を満たす範囲で乱択のアプローチ等によりある程度 $I$ に要素を追加した状態から増加路アルゴリズムを回すことで定数倍高速化し TL に間に合わせられる．
+- [2128 - Demonstration of Honesty! - URI Online Judge / beecrowd](https://www.beecrowd.com.br/judge/en/problems/view/2128) 各辺に色がついている無向グラフで，同色の辺は一度しか使えない全域木構築判定問題．グラフマトロイドと分割マトロイドの交差． `MatroidIntersection()` 関数では，重みなしの場合のみ前処理として独立性を満たす範囲で簡易的な評価で $I$ に各要素を追加している．これにより増加路探索の回数が削減されることで定数倍が大きく改善し，本ライブラリをそのまま貼るだけで TL に間に合う．
 - [CodeChef October Challenge 2019: Faulty System](https://www.codechef.com/problems/CNNCT2) グラフマトロイドとグラフマトロイドの交差．
 - [Rainbow Graph – Kattis, NAIPC 2018](https://naipc18.kattis.com/problems/rainbowgraph)
 - [Google Code Jam 2019 Round 3 Datacenter Duplex](https://codingcompetitions.withgoogle.com/codejam/round/0000000000051707/0000000000158f1c)


### PR DESCRIPTION
1. マトロイド交差を解くとき、ゼロから一挙に解く関数だけではなく、一回だけ augment する関数もあってもよい
  - 既にある程度 augment した場合から始めたい状況にも対応できそう
     - 例：高速な他のアルゴリズムで途中まで augment できる場合
2. unweighted な場合は、最初は（削除・交換は考えず）追加だけを高速に判定して行って雑に初期解を作った方がよい気がする

ということで 1. に対応して `matroid_intersection_augment()` 関数を生やし、 2. に対応して `MatroidIntersection()` に前処理を追加する。